### PR TITLE
DateRange overrides CurrentDate. The docs say the complete opposite.

### DIFF
--- a/ur_queries.md
+++ b/ur_queries.md
@@ -62,8 +62,8 @@ Query fields determine what data is used to match when returning recommendations
 	* **bias** will either boost the importance of this part of the query or use it as a filter. Positive biases are boosts any negative number will filter out any results that do not contain the values in the field name. See **Biases** above.
 * **num**: optional max number of recommendations to return. There is no guarantee that this number will be returned for every query. Adding backfill in the engine.json will make it much more likely to return this number of recommendations.
 * **blacklistItems**: optional. Unlike the engine.json, which specifies event types this part of the query specifies individual items to remove from returned recommendations. It can be used to remove duplicates when items are already shown in a specific context. This is called anti-flood in recommender use.
-* **dateRange** optional, default is not range filter. One of the bound can be omitted but not both. Values for the `before` and `after` are strings in ISO 8601 format. A date range is ignored if **currentDate** is also specified in the query.
-* **currentDate** optional, must be specified if used. Overrides the **dateRange** is both are in the query.
+* **dateRange** optional, default is not range filter. One of the bound can be omitted but not both. Values for the `before` and `after` are strings in ISO 8601 format. Overrides the **currentDate** if both are in the query.
+* **currentDate** optional, must be specified if used. If **dateRange** is included then **currentDate** is ignored.
 * **returnSelf**: optional boolean asking to include the item that was part of the query (if there was one) as part of the results. Defaults to false.
  
 Defaults are either noted or taken from algorithm values, which themselves may have defaults. This allows very simple queries for the simple, most used cases.


### PR DESCRIPTION
This PR fixes an issue where the universal recommender docs on actionml.com suggest that client defined currentDate overrides a dateRange, but in actuality the opposite appears to be true:

See the line that checks for the existence of DateRange first, and ONLY IF it does NOT exist, will the code use currentDate.
https://github.com/pferrel/template-scala-parallel-universal-recommendation/blob/b361689de70d04f50fa032a77703b0044f64bf6d/src/main/scala/URAlgorithm.scala#L765

Also a few lines above that, line 762, should prob have the code comment corrected as well, but that's in a different repo.
