### PR TITLE
Single machine installation doc to avoid confusion of cloning the pio two times. 

### DIFF
--- a/single_machine.md
+++ b/single_machine.md
@@ -212,7 +212,7 @@ Configure with these changes to `/usr/local/hbase/conf`:
    At this point you should see several different processes start on the master including zookeeper. If there is an error check the log files referenced in the error message.
 
 ## Setup PredictionIO
-   If you have already clonned the actionml version of the PredictionIo from "Download Services On All Hosts: Step 2", you don't need to clone it again, you can proceed to build PredictionIO.
+   If you have already clone the actionml version of the PredictionIo from "Download Services On All Hosts: Step 2", you don't need to clone it again, you can proceed to build PredictionIO.
   {{> build_pio}}
 
 

--- a/single_machine.md
+++ b/single_machine.md
@@ -212,7 +212,7 @@ Configure with these changes to `/usr/local/hbase/conf`:
    At this point you should see several different processes start on the master including zookeeper. If there is an error check the log files referenced in the error message.
 
 ## Setup PredictionIO
-
+   If you have already clonned the actionml version of the PredictionIo from "Download Services On All Hosts: Step 2", you don't need to clone it again, you can proceed to build PredictionIO.
   {{> build_pio}}
 
 

--- a/ur_quickstart.md
+++ b/ur_quickstart.md
@@ -47,6 +47,8 @@ This will populate the local cache with updated Mahout classes that are needed b
 
 ## Build The Universal Recommender
 
+If you have already clone the universal-recommender in the installation process, you don't need to clone it again. 
+
 ```
 git clone https://github.com/actionml/universal-recommender.git ~/ur
 cd ~/ur


### PR DESCRIPTION
There was a confusion in the doc since it tells to clone the pio two times. Once the action-ml version of pio and another is official pio. So a new-bie might get confused during the installation. So to mitigate the confusion, I just added few lines to tell the user that if they have already clone one version, they don't have to clone another. 